### PR TITLE
disable datadog repo

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -25,7 +25,7 @@ class datadog_agent::redhat(
     validate_string($baseurl)
 
     yumrepo {'datadog':
-      enabled  => 1,
+      enabled  => 0,
       gpgcheck => 1,
       gpgkey   => $gpgkey,
       descr    => 'Datadog, Inc.',


### PR DESCRIPTION
Datadog package is currently part of our base image. this would disable the repo and allow the pacakages to be installed from out s3 repo
